### PR TITLE
Add regeneration helper for assessments

### DIFF
--- a/includes/regenerate-assessment.php
+++ b/includes/regenerate-assessment.php
@@ -1,0 +1,23 @@
+<?php
+namespace Jeanius;
+
+/**
+ * Regenerate the Jeanius assessment for a given post ID.
+ *
+ * Clears the current user to the assessment's author so the existing REST
+ * generation logic runs against the correct record, invokes the generator,
+ * then restores the original user context.
+ */
+function regenerate_assessment( int $post_id ): void {
+    $author_id = (int) \get_post_field( 'post_author', $post_id );
+    if ( ! $author_id ) {
+        return;
+    }
+
+    $original = \get_current_user_id();
+    \wp_set_current_user( $author_id );
+
+    Rest::generate_report( new \WP_REST_Request( 'POST', '/jeanius/v1/generate' ) );
+
+    \wp_set_current_user( $original );
+}

--- a/jeanius.php
+++ b/jeanius.php
@@ -82,5 +82,6 @@ function run_jeanius() {
 run_jeanius();
 
 // added from 7/7/2025
-require_once __DIR__ . '/vendor/autoload.php'; 
+require_once __DIR__ . '/vendor/autoload.php';
 require plugin_dir_path( __FILE__ ) . 'includes/extra-functions.php';
+require plugin_dir_path( __FILE__ ) . 'includes/regenerate-assessment.php';


### PR DESCRIPTION
## Summary
- Add `Jeanius\regenerate_assessment` helper that impersonates the post author and invokes the REST generator
- Load regeneration helper from plugin bootstrap so the ACF save_post hook can trigger regeneration

## Testing
- `php -l includes/regenerate-assessment.php`
- `php -l includes/extra-functions.php`
- `php -l jeanius.php`


------
https://chatgpt.com/codex/tasks/task_b_68af61fc31608331a721875e5a0939af